### PR TITLE
Ajustes de navegación y tarjetas

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -39,16 +39,13 @@
                             <a class="nav-link {% if request.endpoint == 'sobre_mi' %}active{% endif %}" href="{{ url_for('sobre_mi') }}">Sobre mí</a>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link dropdown-toggle {% if request.endpoint in ['cucha','trabajos','sintesis','articulos'] %}active{% endif %}" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">Trabajos</a>
+                            <a class="nav-link dropdown-toggle {% if request.endpoint in ['cucha','trabajos','sintesis','articulos'] %}active{% endif %}" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">Proyectos</a>
                             <ul class="dropdown-menu dropdown-menu-dark">
                                 <li><a class="dropdown-item" href="{{ url_for('cucha') }}">Cuchá</a></li>
                                 <li><a class="dropdown-item" href="{{ url_for('trabajos') }}">Trabajos</a></li>
                                 <li><a class="dropdown-item" href="{{ url_for('sintesis') }}">Síntesis Estratégica</a></li>
                                 <li><a class="dropdown-item" href="{{ url_for('articulos') }}">Artículos Académicos</a></li>
                             </ul>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link {% if request.endpoint == 'cv' %}active{% endif %}" href="{{ url_for('cv') }}">CV</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link {% if request.endpoint == 'contacto' %}active{% endif %}" href="{{ url_for('contacto') }}">Contacto</a>

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,10 +11,6 @@
                         Estrategia, comunicación y análisis de datos.<br>
                         Combino pensamiento crítico, narrativas visuales y herramientas digitales para crear soluciones más humanas e inteligentes.
                     </p>
-                    <a class="btn btn-outline-light btn-lg px-4 me-sm-3"
-                       href="{{ url_for('static', filename='docs/Currículum 2025.pdf') }}" download>
-                       Descargar CV
-                    </a>
                 </div>
             </div>
         </div>
@@ -52,7 +48,6 @@
                 {'titulo': '📰 Cuchá', 'texto': 'Medio digital autogestionado. Estrategia de contenido, producción periodística y redes sociales.', 'url': 'cucha'},
                 {'titulo': '📚 Artículos académicos', 'texto': 'Publicaciones y ponencias sobre comunicación, cultura y medios.', 'url': 'articulos'},
                 {'titulo': '🧠 Síntesis estratégica', 'texto': 'Web creada con Python para representar visualmente mi perfil profesional.', 'url': 'sintesis'},
-                {'titulo': '📄 Currículum Vitae', 'texto': 'Detalles completos de mi formación y experiencia profesional.', 'url': 'cv'},
                 {'titulo': '👤 Sobre mí', 'texto': 'Formación, experiencia y competencias técnicas como comunicador y analista de datos.', 'url': 'sobre_mi'},
                 {'titulo': '📬 Contacto', 'texto': '¿Querés escribirme o ponerte en contacto? Encontrá mis datos y redes en esta sección.', 'url': 'contacto'}
             ] %}

--- a/templates/sobre_mi.html
+++ b/templates/sobre_mi.html
@@ -49,7 +49,7 @@
                 </p>
 
                 <p>
-                    Si querés conocer más sobre mi recorrido profesional, formación, competencias técnicas y experiencias, podés consultar el <a href="{{ url_for('static', filename='docs/Currículum 2025.pdf') }}" target="_blank"><strong>CV completo</strong></a> que elaboré en base a estos proyectos, trabajos y aprendizajes.
+                    Si querés conocer más sobre mi recorrido profesional, formación, competencias técnicas y experiencias, podés consultar el <a href="{{ url_for('cv') }}"><strong>CV completo</strong></a> que elaboré en base a estos proyectos, trabajos y aprendizajes.
                 </p>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- renombra la opción desplegable a *Proyectos*
- elimina acceso directo al CV desde la barra de navegación
- quita el botón de descarga y la tarjeta de CV en la página de inicio
- agrega enlace al CV dentro de la sección "Sobre mí"

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6872902d0fcc832385d72b1a5d2ded94