### PR TITLE
Add CV dropdown and button

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -35,8 +35,12 @@
                         <li class="nav-item">
                             <a class="nav-link {% if request.endpoint == 'index' %}active{% endif %}" href="{{ url_for('index') }}">Inicio</a>
                         </li>
-                        <li class="nav-item">
-                            <a class="nav-link {% if request.endpoint == 'sobre_mi' %}active{% endif %}" href="{{ url_for('sobre_mi') }}">Sobre mí</a>
+                        <li class="nav-item dropdown">
+                            <a class="nav-link dropdown-toggle {% if request.endpoint in ['sobre_mi','cv'] %}active{% endif %}" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">Sobre mí</a>
+                            <ul class="dropdown-menu dropdown-menu-dark">
+                                <li><a class="dropdown-item" href="{{ url_for('sobre_mi') }}">Mi trayectoria</a></li>
+                                <li><a class="dropdown-item" href="{{ url_for('cv') }}">Mi CV</a></li>
+                            </ul>
                         </li>
                         <li class="nav-item dropdown">
                             <a class="nav-link dropdown-toggle {% if request.endpoint in ['cucha','trabajos','sintesis','articulos'] %}active{% endif %}" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">Proyectos</a>

--- a/templates/sobre_mi.html
+++ b/templates/sobre_mi.html
@@ -5,6 +5,7 @@
     <div class="container px-5 text-center">
         <h1 class="display-4 fw-bolder">Sobre mí</h1>
         <p class="lead">Un recorrido personal y profesional</p>
+        <a class="btn btn-primary mt-3" href="{{ url_for('cv') }}">Ver CV completo</a>
     </div>
 </header>
 


### PR DESCRIPTION
## Summary
- add a dropdown under **Sobre mí** in the navbar with links to "Mi trayectoria" and "Mi CV"
- insert a button in the *Sobre mí* page that links to the CV page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687292ee3ae08323822e6879d0620631