### PR TITLE
Add header links and restructure CV list

### DIFF
--- a/templates/cv.html
+++ b/templates/cv.html
@@ -23,10 +23,14 @@
                 <h5 class="fw-bold mt-4">Formación Académica</h5>
                 <ul>
                     <li>Licenciatura en Comunicación Social (orientación en comunicación audiovisual) - UNC, 2007-2013</li>
-                    <li>Formación en Teoría Social y Antropología - UNC</li>
-                    <li>Curso de Python – Coderhouse (52 hs) – 2025</li>
-                    <li>Curso de Excel – Coderhouse (20 hs) – 2025</li>
-                    <li>Diplomatura en Data Analytics – En curso, Mundo E</li>
+                    <li>Formación en Teoría Social y Antropología - UNC, que incluye cursos de posgrado de orientación teórica y metodológica.</li>
+                    <li>Formación en Análisis de Datos:
+                        <ul>
+                            <li>Curso de Python – Coderhouse (52 hs) – 2025</li>
+                            <li>Curso de Excel – Coderhouse (20 hs) – 2025</li>
+                            <li>Diplomatura en Data Analytics – En curso, Mundo E</li>
+                        </ul>
+                    </li>
                 </ul>
 
                 <h5 class="fw-bold mt-4">Experiencia Profesional</h5>

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,6 +11,14 @@
                         Estrategia, comunicación y análisis de datos.<br>
                         Combino pensamiento crítico, narrativas visuales y herramientas digitales para crear soluciones más humanas e inteligentes.
                     </p>
+                    <div class="d-flex justify-content-center gap-3">
+                        <a class="btn btn-outline-light" href="https://www.linkedin.com/in/santi-bonacci-85b28570" target="_blank">
+                            <i class="bi bi-linkedin"></i> LinkedIn
+                        </a>
+                        <a class="btn btn-primary" href="{{ url_for('static', filename='docs/Currículum 2025.pdf') }}" download>
+                            <i class="bi bi-download"></i> Descargar CV
+                        </a>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- show LinkedIn and CV download buttons on the homepage
- restructure academic formation section in CV

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872c38c17ec8323a6138062f12539e6