### PR TITLE
Remove redundant LinkedIn link

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -19,9 +19,6 @@
                             <i class="bi bi-download"></i> Descargar CV
                         </a>
                     </div>
-                    <div class="text-center mt-2">
-                        <a href="https://www.linkedin.com/in/santi-bonacci-85b28570" target="_blank" class="text-white text-decoration-none">Conectá conmigo en LinkedIn</a>
-                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- remove duplicated "Conectá conmigo en LinkedIn" text link from home page

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6872ca950cfc832391bc94b018a44507