### PR TITLE
Update portfolio content and styles

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -50,23 +50,6 @@ h1, h2, h5 {
     font-weight: bold;
 }
 
-/* Animación de aparición (fade-in) */
-@keyframes fadeInUp {
-    from {
-        opacity: 0;
-        transform: translateY(20px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
-
-/* Aplicar animación a secciones */
-/* Se elimina la animación de aparición en secciones y tarjetas */
-section, .card {
-    /* animation: fadeInUp 0.8s ease-in-out; */
-}
 
 /* Mejor estética para párrafos introductorios */
 section.bg-light p.lead {
@@ -81,19 +64,6 @@ section.bg-light p.lead {
     }
 }
 
-/* Animación fade-in */
-.fade-in-section {
-    opacity: 0;
-    transform: translateY(20px);
-    animation: fadeInUp 1s ease-out forwards;
-}
-
-@keyframes fadeInUp {
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
 
 /* Estilo para imágenes responsivas y modernas */
 .img-mod {

--- a/templates/cv.html
+++ b/templates/cv.html
@@ -25,7 +25,14 @@
                 <ul>
                     <li>Licenciatura en Comunicación Social (orientación en comunicación audiovisual) - UNC, 2007-2013</li>
                     <li>Formación en Teoría Social y Antropología - UNC, que incluye cursos de posgrado de orientación teórica y metodológica.</li>
-                    <li>Formación en Análisis de Datos: en <strong>Coderhouse</strong> y la diplomatura de <strong>Mundo E</strong>. Cursos aprobados de <em>Python</em>, <em>Excel</em> y <em>Tableau</em>.</li>
+                    <li>Formación en Análisis de Datos:
+                        <ul>
+                            <li>Curso de Python – Coderhouse (52 hs) – 2025</li>
+                            <li>Curso de Excel – Coderhouse (20 hs) – 2025</li>
+                            <li>Curso de Tableau – Coderhouse (20 hs) – 2025</li>
+                            <li>Diplomatura en Data Analytics – Mundo E (en curso)</li>
+                        </ul>
+                    </li>
                 </ul>
 
                 <h5 class="fw-bold mt-4">Experiencia Profesional</h5>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
 <!-- Header personalizado -->
-<header class="py-5" style="background: url('{{ url_for('static', filename='assets/fondo1.png') }}') center center / cover no-repeat;">
+<header class="py-5" style="background: linear-gradient(rgba(255,255,255,0.5), rgba(255,255,255,0.5)), url('{{ url_for('static', filename='assets/fondo1.png') }}') center center / cover no-repeat;">
     <div class="container px-5">
         <div class="row gx-5 justify-content-center">
             <div class="col-lg-8">
@@ -39,7 +39,7 @@
 
 <!-- Secciones destacadas con fondo -->
 <section class="py-5" id="resumen"
-         style="background: url('{{ url_for('static', filename='assets/fondo10.png') }}') center center / cover no-repeat;">
+         style="background: linear-gradient(rgba(255,255,255,0.5), rgba(255,255,255,0.5)), url('{{ url_for('static', filename='assets/fondo10.png') }}') center center / cover no-repeat;">
     <div class="container px-5 my-5">
         <div class="row gx-5 justify-content-center mb-5">
             <div class="col-lg-8 text-center">
@@ -85,7 +85,7 @@
             <div class="col-lg-6 mb-4">
                 <div class="card h-100 shadow-sm"><div class="card-body">
                     <h5 class="card-title">📊 Formación en Análisis de Datos</h5>
-                    <p class="card-text">Actualmente me estoy formando en Python, Excel avanzado, Tableau y Power BI, integrando estos conocimientos a mi perfil comunicacional.</p>
+                    <p class="card-text">Actualmente curso Python (52&nbsp;hs), Excel (20&nbsp;hs), Tableau (20&nbsp;hs) y Power BI, integrando estos conocimientos a mi perfil comunicacional.</p>
                 </div></div>
             </div>
             <div class="col-lg-6 mb-4">
@@ -123,7 +123,7 @@
 </section>
 
 <!-- Créditos de desarrollo -->
-<section class="py-4 bg-white border-top fade-in-section">
+<section class="py-4 bg-white border-top">
     <div class="container px-5">
         <div class="text-center">
             <p class="text-muted mb-1">💻 Esta página fue realizada íntegramente por Santiago Bonacci.</p>

--- a/templates/sobre_mi.html
+++ b/templates/sobre_mi.html
@@ -45,7 +45,7 @@
                 </p>
 
                 <p>
-                    Actualmente me estoy formando como analista de datos mediante cursos en <strong>Coderhouse</strong> y la Diplomatura en Data Analytics de <strong>Mundo E</strong>. Ya aprobé los módulos de <em>Excel</em>, <em>Tableau</em> y <em>Python</em>, integrándolos a mi trabajo de comunicación estratégica.
+                    Actualmente me estoy formando como analista de datos mediante cursos en <strong>Coderhouse</strong> y la Diplomatura en Data Analytics de <strong>Mundo E</strong>. Ya aprobé los cursos de <em>Python</em> (52&nbsp;hs, 2025), <em>Excel</em> (20&nbsp;hs, 2025) y <em>Tableau</em> (20&nbsp;hs, 2025), integrándolos a mi trabajo de comunicación estratégica.
                 </p>
 
                 <p>


### PR DESCRIPTION
## Summary
- remove unused fade-in animation
- expand analysis courses in CV
- mention course details on About and logros card
- adjust homepage backgrounds with transparency

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687c6cae8bd083239f5165314302ee7c