### PR TITLE
Adjust card styles

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -18,7 +18,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .card:hover {
-    transform: translateY(-6px) scale(1.01);
+    transform: translateY(-5px);
     transition: transform 0.3s ease-in-out, box-shadow 0.3s ease-in-out;
     box-shadow: 0 10px 20px rgba(0, 0, 0, 0.15);
 }
@@ -26,7 +26,7 @@ h1, h2, h3, h4, h5, h6 {
 /* Fondo con opacidad en tarjetas con imagen */
 .card-body {
     /* Se aumenta la transparencia general de las tarjetas */
-    background-color: rgba(255, 255, 255, 0.8);
+    background-color: rgba(255, 255, 255, 0.95);
     backdrop-filter: blur(6px);
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -61,7 +61,7 @@
             ] %}
             {% for item in secciones %}
             <div class="col-lg-4 mb-4">
-                <div class="card h-100 border-0 shadow-lg" style="transition: transform 0.3s; background: rgba(255, 255, 255, 0.85); backdrop-filter: blur(5px);">
+                <div class="card h-100 shadow-lg border-0" style="transition: transform 0.3s; background-color: rgba(255, 255, 255, 0.95);">
                     <div class="card-body p-4">
                         <h5 class="card-title text-dark">{{ item.titulo }}</h5>
                         <p class="card-text text-dark">{{ item.texto }}</p>


### PR DESCRIPTION
## Summary
- change inline card style with subtle transparent background in `index.html`
- tweak card hover effect and transparency in `style.css`

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_687c7e9cb6608323a7142005423e4cf1