### PR TITLE
Ajustes de estilo y fuente

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,6 +1,6 @@
 /* Estilo general */
 body {
-    font-family: 'Poppins', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    font-family: 'Montserrat', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
     scroll-behavior: smooth;
 }
 
@@ -17,11 +17,9 @@ body {
     box-shadow: 0 10px 20px rgba(0, 0, 0, 0.15);
 }
 
-/* Fondo con opacidad en tarjetas con imagen */
+/* Fondo de las tarjetas */
 .card-body {
-    /* Se aumenta la transparencia general de las tarjetas */
-    background-color: rgba(255, 255, 255, 0.8);
-    backdrop-filter: blur(6px);
+    background-color: #fff;
 }
 
 /* Estilos y animaciones para botones */

--- a/templates/base.html
+++ b/templates/base.html
@@ -14,7 +14,7 @@
         <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.4.1/font/bootstrap-icons.css" rel="stylesheet" />
 
         <!-- Fuente Google -->
-        <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;600&display=swap" rel="stylesheet">
 
         <!-- Estilos personalizados -->
         <link href="{{ url_for('static', filename='css/styles.css') }}" rel="stylesheet" />

--- a/templates/index.html
+++ b/templates/index.html
@@ -63,7 +63,7 @@
             ] %}
             {% for item in secciones %}
             <div class="col-lg-4 mb-4">
-                <div class="card h-100 border-0 shadow-lg" style="transition: transform 0.3s; background: rgba(255, 255, 255, 0.85); backdrop-filter: blur(5px);">
+                <div class="card h-100 border-0 shadow-lg" style="transition: transform 0.3s;">
                     <div class="card-body p-4">
                         <h5 class="card-title text-dark">{{ item.titulo }}</h5>
                         <p class="card-text text-dark">{{ item.texto }}</p>


### PR DESCRIPTION
## Resumen
- cambiar fuente global a Montserrat
- quitar superposicion blanca en tarjetas de inicio
- ajustar fondo de tarjetas sin transparencia

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687db84fffac8323bfaa743c0e97d507