### PR TITLE
Corrige enlace de informe y reorganiza sección Cuchá

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,7 +20,7 @@ TRABAJOS = [
     {
         "titulo": "Informe de Métricas de Instagram – T2 2025",
         "descripcion": "Diagnóstico del segundo trimestre 2025 comparado con siete previos.",
-        "link": "docs/Informe Metricas T2 Cucha.pdf",
+        "link": "docs/INFORME MÉTRICAS T2 CUCHÁ.pdf",
         "externo": False,
         "fecha": datetime(2025, 8, 15),
     },

--- a/templates/cucha.html
+++ b/templates/cucha.html
@@ -51,70 +51,6 @@
             <img src="{{ url_for('static', filename='assets/CUCHÁ_Logo-10.png') }}" alt="Logo de Cuchá" class="img-fluid logo-img responsive-img" />
         </div>
 
-        <!-- Videos virales -->
-        <div class="mt-5">
-            <h4 class="mb-2">🎬 Videos virales en redes</h4>
-            <p class="text-muted">Producciones audiovisuales que edité y publiqué para Cuchá, y que lograron gran alcance.</p>
-
-            <div class="row gy-4">
-
-                <!-- Video 1 -->
-                <div class="col-md-6">
-                    <div class="card h-100 border-0 shadow-sm">
-                        <div class="ratio ratio-16x9">
-                            <iframe src="https://www.tiktok.com/embed/v2/7534335335875071238" allowfullscreen></iframe>
-                        </div>
-                        <div class="card-body">
-                            <p class="card-text">La exploración en las profundidades del mar argentino 🌊 está revelando un mundo desconocido. Desde el buque Falkor (too) 🚢, un equipo de científicos argentinos desciende con el robot submarino SuBastian hasta el Cañón Submarino de Mar del Plata, capturando en 4K la vida oculta del Atlántico Sur: peces abisales, corales de aguas frías y esponjas traslúcidas. En el marco de la misión Talud Continental IV 🔬, investigan biodiversidad, impacto humano y cambio climático, compartiendo en vivo sus hallazgos con el mundo y acercando la ciencia argentina a miles de personas que, por primera vez, pueden asomarse a las profundidades de nuestros mares.</p>
-                            <a href="https://www.tiktok.com/@cucha.cordoba/video/7534335335875071238" class="btn btn-sm btn-primary" target="_blank">Ver en TikTok</a>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Video 2 -->
-                <div class="col-md-6">
-                    <div class="card h-100 border-0 shadow-sm">
-                        <div class="ratio ratio-16x9">
-                            <iframe src="https://www.tiktok.com/embed/v2/7498928102798658821" allowfullscreen></iframe>
-                        </div>
-                        <div class="card-body">
-                            <p class="card-text">Las Unidades Turísticas de #Embalse, ícono del #TurismoSocial argentino, fueron construidas entre 1946 y 1951 como parte del Plan Quinquenal impulsado por Juan Domingo Perón. #Monumento Histórico Nacional desde 2013, hoy enfrentan el avance de políticas de abandono y privatización. Un legado de inclusión que corre peligro. #Córdoba #Patrimonio</p>
-                            <a href="https://www.tiktok.com/@cucha.cordoba/video/7498928102798658821" class="btn btn-sm btn-primary" target="_blank">Ver en TikTok</a>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Video 3 -->
-                <div class="col-md-6">
-                    <div class="card h-100 border-0 shadow-sm">
-                        <div class="ratio ratio-16x9">
-                            <iframe src="https://www.instagram.com/reel/DJrCWrou7J1/embed" allowfullscreen></iframe>
-                        </div>
-                        <div class="card-body">
-                            <p class="card-text">🎶 Hoy cumpliría 100 años una de las voces más emblemáticas del cancionero popular argentino. Cantor del pueblo, de la tierra y de la libertad, Horacio Guarany fue un artista profundamente arraigado a su gente y a su historia. Sufrió persecución y exilio, pero nunca dejó de cantar. Su obra sigue viva en cada zamba, chacarera y milonga que lo recuerda.</p>
-                            <a href="https://www.instagram.com/cucha.cba/reel/DJrCWrou7J1/" class="btn btn-sm btn-danger" target="_blank">Ver en Instagram</a>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Video 4 -->
-                <div class="col-md-6">
-                    <div class="card h-100 border-0 shadow-sm">
-                        <div class="ratio ratio-16x9">
-                            <iframe src="https://www.instagram.com/reel/DLLepydPZ46/embed" allowfullscreen></iframe>
-                        </div>
-                        <div class="card-body">
-                            <p class="card-text">Durante la dictadura, el cuarteto enfrentó censura y persecución por ser considerado “incultura”. El régimen buscaba esconderlo del Mundial 78, pero artistas como La Mona resistieron y mantuvieron viva la cultura popular cordobesa. #Cuarteto #MonaJiménez #Córdoba #Memoria #CulturaPopular #Dictadura #Mundial78 #CensuraCultural #Identidad #Cultura #Música</p>
-                            <a href="https://www.instagram.com/cucha.cba/reel/DLLepydPZ46/" class="btn btn-sm btn-danger" target="_blank">Ver en Instagram</a>
-                        </div>
-                    </div>
-                </div>
-
-            </div>
-
-            <p class="text-muted mt-3"><small>Los videos fueron producidos, editados y publicados por mí en las redes de Cuchá.</small></p>
-        </div>
-
         <!-- Notas destacadas -->
         <div class="mt-5">
             <h4 class="mb-2">📝 Notas escritas por mí</h4>
@@ -168,6 +104,67 @@
 
             </div>
         </div>
+
+        <!-- Videos virales -->
+        <div class="mt-5">
+            <h4 class="mb-2">🎬 Videos virales en redes</h4>
+            <p class="text-muted">Producciones audiovisuales que edité y publiqué para Cuchá, y que lograron gran alcance.</p>
+
+            <div class="row gy-4">
+
+                <!-- Video 1 -->
+                <div class="col-md-6">
+                    <div class="card h-100 border-0 shadow-sm">
+                        <div class="ratio ratio-9x16">
+                            <iframe src="https://www.tiktok.com/embed/v2/7534335335875071238" style="border:none;overflow:hidden;" scrolling="no" allowfullscreen></iframe>
+                        </div>
+                        <div class="card-body text-center">
+                            <a href="https://www.tiktok.com/@cucha.cordoba/video/7534335335875071238" class="btn btn-sm btn-primary" target="_blank">Ver en TikTok</a>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Video 2 -->
+                <div class="col-md-6">
+                    <div class="card h-100 border-0 shadow-sm">
+                        <div class="ratio ratio-9x16">
+                            <iframe src="https://www.tiktok.com/embed/v2/7498928102798658821" style="border:none;overflow:hidden;" scrolling="no" allowfullscreen></iframe>
+                        </div>
+                        <div class="card-body text-center">
+                            <a href="https://www.tiktok.com/@cucha.cordoba/video/7498928102798658821" class="btn btn-sm btn-primary" target="_blank">Ver en TikTok</a>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Video 3 -->
+                <div class="col-md-6">
+                    <div class="card h-100 border-0 shadow-sm">
+                        <div class="ratio ratio-9x16">
+                            <iframe src="https://www.instagram.com/reel/DJrCWrou7J1/embed" style="border:none;overflow:hidden;" scrolling="no" allowfullscreen></iframe>
+                        </div>
+                        <div class="card-body text-center">
+                            <a href="https://www.instagram.com/cucha.cba/reel/DJrCWrou7J1/" class="btn btn-sm btn-danger" target="_blank">Ver en Instagram</a>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Video 4 -->
+                <div class="col-md-6">
+                    <div class="card h-100 border-0 shadow-sm">
+                        <div class="ratio ratio-9x16">
+                            <iframe src="https://www.instagram.com/reel/DLLepydPZ46/embed" style="border:none;overflow:hidden;" scrolling="no" allowfullscreen></iframe>
+                        </div>
+                        <div class="card-body text-center">
+                            <a href="https://www.instagram.com/cucha.cba/reel/DLLepydPZ46/" class="btn btn-sm btn-danger" target="_blank">Ver en Instagram</a>
+                        </div>
+                    </div>
+                </div>
+
+            </div>
+
+            <p class="text-muted mt-3"><small>Los videos fueron producidos, editados y publicados por mí en las redes de Cuchá.</small></p>
+        </div>
+
 
     </div>
 </section>

--- a/templates/trabajos.html
+++ b/templates/trabajos.html
@@ -22,7 +22,7 @@
                         <p>
                             Análisis del período abril-junio de 2025 comparado con los siete trimestres previos. Evalúa vistas, alcance, interacciones, tasa de interacción y seguidores ganados para optimizar la estrategia editorial.
                         </p>
-                        <a href="{{ url_for('static', filename='docs/Informe Metricas T2 Cucha.pdf') }}" target="_blank" class="btn btn-outline-primary mt-3">📄 Descargar Informe PDF</a>
+                        <a href="{{ url_for('static', filename='docs/INFORME MÉTRICAS T2 CUCHÁ.pdf') }}" target="_blank" class="btn btn-outline-primary mt-3">📄 Descargar Informe PDF</a>
                         <p class="text-muted small mt-2 mb-0">Agosto 2025</p>
                     </div>
                 </div>


### PR DESCRIPTION
## Resumen
- Corrige el enlace al PDF de métricas T2 2025.
- Reordena la página de Cuchá: notas antes que videos.
- Ajusta los iframes de video (ratio 9x16, sin descripciones) para evitar barras de desplazamiento.

## Pruebas
- `pytest` (sin tests)
- `python -m py_compile app.py`
- `pip install flake8 pytest` (falló: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68a518aba40c83238f503dc38662f1ef