### PR TITLE
Mostrar previsualización de videos verticales en Cuchá

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -93,3 +93,9 @@ section.bg-light p.lead {
     border-radius: 12px;
     box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
 }
+
+/* Soporte para videos verticales */
+.ratio-9x16 {
+    --bs-aspect-ratio: 177.78%;
+}
+


### PR DESCRIPTION
## Summary
- Añade una clase CSS `ratio-9x16` para que los iframes de TikTok e Instagram se muestren correctamente en formato vertical.

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a51fad4b4083239982c6eebf523221