### PR TITLE
Arregla enlace de informe de métricas en trabajos

### DIFF
--- a/app.py
+++ b/app.py
@@ -34,7 +34,7 @@ TRABAJOS = [
     {
         "titulo": "Informe Estratégico sobre Rendimiento en Instagram",
         "descripcion": "Informe de métricas clave y recomendaciones.",
-        "link": "docs/Métricas Cuchá 23-25.pdf",
+        "link": "docs/Informe Metricas Instagram Junio 2023 - Julio 2025.pdf",
         "externo": False,
         "fecha": datetime(2025, 7, 15),
     },


### PR DESCRIPTION
## Resumen
- Corrige la ruta del PDF *Informe Metricas Instagram Junio 2023 - Julio 2025* en la lista de trabajos.

## Pruebas
- `python -m py_compile app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a52aee85688323b8082b6a046ce06c