### PR TITLE
Corrige enlace de LinkedIn y narrativa sobre Cuchá

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -70,7 +70,7 @@
                    <a href="mailto:sbonacci89@gmail.com" class="text-white">sbonacci89@gmail.com</a> ·
 
                     
-                    <a href="https://www.linkedin.com/in/santi-bonacci-85b28570" target="_blank" class="text-white">LinkedIn</a>
+                    <a href="https://www.linkedin.com/in/santiago-bonacci-85b28570/" target="_blank" class="text-white">LinkedIn</a>
                 </p>
             </div>
         </footer>

--- a/templates/contacto.html
+++ b/templates/contacto.html
@@ -28,7 +28,7 @@
                             </li>
                             <li class="mb-3">
                                 <strong>🔗 LinkedIn:</strong> <br>
-                                <a href="https://www.linkedin.com/in/santi-bonacci-85b28570" target="_blank" class="text-decoration-none">/in/santi-bonacci</a>
+                                <a href="https://www.linkedin.com/in/santiago-bonacci-85b28570/" target="_blank" class="text-decoration-none">/in/santiago-bonacci</a>
                             </li>
                             <li>
                                 <strong>📷 Instagram:</strong> <br>

--- a/templates/index.html
+++ b/templates/index.html
@@ -13,7 +13,7 @@
                         Profesional de la comunicación orientado al análisis de datos, con experiencia en métricas de redes sociales, reporting y <strong>SEO</strong>. Integro herramientas como <strong>Excel</strong>, <strong>Power BI</strong>, <strong>Tableau</strong>, <strong>Python</strong> y <strong>SQL</strong> con una mirada estratégica capaz de traducir información compleja en diagnósticos accionables.
                     </p>
                     <div class="d-flex justify-content-center gap-3">
-                        <a class="btn btn-outline-light" href="https://www.linkedin.com/in/santi-bonacci-85b28570" target="_blank">
+                        <a class="btn btn-outline-light" href="https://www.linkedin.com/in/santiago-bonacci-85b28570/" target="_blank">
                             <i class="bi bi-linkedin"></i> LinkedIn
                         </a>
                         <a class="btn btn-primary" href="{{ url_for('static', filename='docs/Currículum 2025.pdf') }}" download>
@@ -133,7 +133,7 @@
             <div class="col-lg-6 mb-4">
                 <div class="card h-100 shadow-sm"><div class="card-body">
                     <h5 class="card-title">📰 Fundador de Cuchá</h5>
-                    <p class="card-text">Cofundé el medio digital @cucha.cba, que alcanzó más de 20.000 seguidores en dos años, consolidándose como un espacio de referencia en narrativas sociales y jóvenes en Córdoba.</p>
+                    <p class="card-text">Cofundé el medio digital @cucha.cba, que alcanzó más de 20.000 seguidores en dos años, consolidándose como un espacio de referencia en narrativas digitales en Córdoba.</p>
                 </div></div>
             </div>
             <div class="col-lg-6 mb-4">


### PR DESCRIPTION
## Resumen
- Actualiza el enlace de LinkedIn a la URL correcta en todas las plantillas.
- Ajusta la narrativa de Cuchá para destacar "narrativas digitales".

## Pruebas
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8e7b694e48323bb71e374eba2fc51